### PR TITLE
Add CloudFront support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,11 @@
     "description": "BEdita 4 plugin for applications that use AWS resources such as S3",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.2.0",
+        "league/flysystem": "^1.0.53",
         "league/flysystem-aws-s3-v3": "^1.0.0",
         "aws/aws-sdk-php": "^3.0.0",
-        "cakephp/cakephp": "~3.4"
+        "cakephp/cakephp": "~3.10"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
+++ b/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
@@ -90,11 +90,11 @@ class AwsS3CloudFrontAdapter extends AwsS3Adapter
     protected function applyCloudFrontPathPrefix($path): string
     {
         $path = '/' . ltrim($path, '/');
-        if (empty($this->options['cloudfrontPathPrefix'])) {
+        if (empty($this->options['cloudFrontPathPrefix'])) {
             return $path;
         }
 
-        return '/' . ltrim($this->options['cloudfrontPathPrefix'], '/') . $path;
+        return '/' . trim($this->options['cloudFrontPathPrefix'], '/') . $path;
     }
 
     /**

--- a/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
+++ b/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
@@ -19,6 +19,9 @@ use Aws\S3\S3ClientInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\Config;
 
+/**
+ * AWS S3 adapter that creates a CloudFront invalidation every time an object is updated or deleted.
+ */
 class AwsS3CloudFrontAdapter extends AwsS3Adapter
 {
     /**

--- a/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
+++ b/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
@@ -34,8 +34,9 @@ class AwsS3CloudFrontAdapter extends AwsS3Adapter
      */
     public function copy($path, $newpath)
     {
+        $existed = $this->has($newpath);
         $result = parent::copy($path, $newpath);
-        if ($result !== false) {
+        if ($result !== false && $existed) {
             $this->createCloudFrontInvalidation($newpath);
         }
 
@@ -47,8 +48,9 @@ class AwsS3CloudFrontAdapter extends AwsS3Adapter
      */
     public function delete($path)
     {
+        $existed = $this->has($path);
         $result = parent::delete($path);
-        if ($result !== false) {
+        if ($result !== false && $existed) {
             $this->createCloudFrontInvalidation($path);
         }
 
@@ -73,8 +75,9 @@ class AwsS3CloudFrontAdapter extends AwsS3Adapter
      */
     public function upload($path, $body, Config $config)
     {
+        $existed = $this->has($path);
         $result = parent::upload($path, $body, $config);
-        if ($result !== false) {
+        if ($result !== false && $existed) {
             $this->createCloudFrontInvalidation($path);
         }
 

--- a/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
+++ b/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace BEdita\AWS\Filesystem\Adapter;
+
+use Aws\CloudFront\CloudFrontClient;
+use Aws\CloudFront\Exception\CloudFrontException;
+use Aws\S3\S3ClientInterface;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Config;
+
+class AwsS3CloudFrontAdapter extends AwsS3Adapter
+{
+    /**
+     * CloudFront Client instance.
+     *
+     * @var \Aws\CloudFront\CloudFrontClient|null
+     */
+    protected $cloudfrontClient = null;
+
+    /**
+     * @inheritdoc
+     *
+     * @param \Aws\CloudFront\CloudFrontClient|null $cloudfrontClient CloudFront client instance, or `null`.
+     */
+    public function __construct(S3ClientInterface $client, $bucket, $prefix = '', array $options = [], $streamReads = true, CloudFrontClient $cloudfrontClient = null)
+    {
+        parent::__construct($client, $bucket, $prefix, $options, $streamReads);
+
+        $this->cloudfrontClient = $cloudfrontClient;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function copy($path, $newpath)
+    {
+        $result = parent::copy($path, $newpath);
+        if ($result !== false) {
+            $this->createCloudFrontInvalidation($newpath);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delete($path)
+    {
+        $result = parent::delete($path);
+        if ($result !== false) {
+            $this->createCloudFrontInvalidation($path);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deleteDir($dirname)
+    {
+        $result = parent::deleteDir($dirname);
+        if ($result !== false) {
+            $this->createCloudFrontInvalidation(rtrim($dirname, '/') . '/*');
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function upload($path, $body, Config $config)
+    {
+        $result = parent::upload($path, $body, $config);
+        if ($result !== false) {
+            $this->createCloudFrontInvalidation($path);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Apply CloudFront path prefix.
+     *
+     * @param string $path Path to prefix.
+     * @return string
+     */
+    protected function applyCloudFrontPathPrefix($path): string
+    {
+        $path = '/' . ltrim($path, '/');
+        if (empty($this->options['cloudfrontPathPrefix'])) {
+            return $path;
+        }
+
+        return '/' . ltrim($this->options['cloudfrontPathPrefix'], '/') . $path;
+    }
+
+    /**
+     * Create CloudFront invalidation.
+     *
+     * @param string $path Path.
+     * @return void
+     */
+    protected function createCloudFrontInvalidation($path): void
+    {
+        if ($this->cloudfrontClient === null || empty($this->options['distributionId'])) {
+            return;
+        }
+
+        try {
+            $this->cloudfrontClient->createInvalidation([
+                'DistributionId' => $this->options['distributionId'],
+                'InvalidationBatch' => [
+                    'CallerReference' => uniqid($path),
+                    'Paths' => [
+                        'Items' => [$this->applyCloudFrontPathPrefix($path)],
+                        'Quantity' => 1,
+                    ],
+                ],
+            ]);
+        } catch (CloudFrontException $e) {
+            triggerWarning(sprintf('Unable to create CloudFront invalidation: %s', $e->getMessage()));
+        }
+    }
+}

--- a/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
+++ b/src/Filesystem/Adapter/AwsS3CloudFrontAdapter.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2022 Atlas Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
 
 namespace BEdita\AWS\Filesystem\Adapter;
 

--- a/src/Filesystem/Adapter/S3Adapter.php
+++ b/src/Filesystem/Adapter/S3Adapter.php
@@ -13,10 +13,10 @@
 
 namespace BEdita\AWS\Filesystem\Adapter;
 
+use Aws\CloudFront\CloudFrontClient;
 use Aws\S3\S3Client;
 use BEdita\AWS\AwsConfigTrait;
 use BEdita\Core\Filesystem\FilesystemAdapter;
-use League\Flysystem\AwsS3v3\AwsS3Adapter;
 
 /**
  * AWS S3 adapter.
@@ -45,6 +45,13 @@ class S3Adapter extends FilesystemAdapter
     protected $client;
 
     /**
+     * AWS CloudFront client.
+     *
+     * @var \Aws\CloudFront\CloudFrontClient|null
+     */
+    protected $cloudFrontClient;
+
+    /**
      * {@inheritDoc}
      */
     public function initialize(array $config)
@@ -69,15 +76,32 @@ class S3Adapter extends FilesystemAdapter
     }
 
     /**
+     * Get AWS CloudFront client.
+     *
+     * @return \Aws\CloudFront\CloudFrontClient|null
+     */
+    protected function getCloudFrontClient()
+    {
+        if (!empty($this->cloudFrontClient)) {
+            return $this->cloudFrontClient;
+        } elseif ($this->getConfig('distributionId') === null) {
+            return null;
+        }
+
+        return $this->cloudFrontClient = new CloudFrontClient($this->getConfig());
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function buildAdapter(array $config)
     {
-        return new AwsS3Adapter(
+        return new AwsS3CloudFrontAdapter(
             $this->getClient(),
             $this->getConfig('host'),
             $this->getConfig('path'),
-            (array)$this->getConfig('options')
+            (array)$this->getConfig('options'),
+            $this->getCloudFrontClient()
         );
     }
 


### PR DESCRIPTION
This MR adds support for assets hosted on an S3 bucket and served through CloudFront.

By adding a `distributionId` option to the S3 adapter config, the adapter takes care of creating invalidations when streams are deleted or replaced.

### Pricing

At the time of this writing, [CloudFront pricing](https://aws.amazon.com/cloudfront/pricing/) works as follows for invalidations:

> No additional charge for the first 1,000 paths requested for invalidation each month. Thereafter, $0.005 per path requested for invalidation.

Every updated or deleted stream may cause up to two invalidations, so depending on the amount of streams replaced or removed every month, enabling this feature may incur in additional costs.