### PR TITLE
Run unit tests against lowest-matching dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '7.2'
-          tools: 'composer'
+          tools: 'composer:v1'
           extensions: 'mbstring, intl'
 
       - name: 'Discover Composer cache directory'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,9 +156,9 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '7.4'
+          php-version: '7.2'
           tools: 'composer'
-          extensions: 'mbstring, intl, pdo_sqlite'
+          extensions: 'mbstring, intl'
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,3 +144,40 @@ jobs:
           name: 'PHP ${{ matrix.php }}'
           path: 'clover.xml'
 
+  unit-lowest:
+    name: 'Run unit tests with lowest-matching dependencies versions'
+    if: "!contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-20.04'
+
+    steps:
+      - name: 'Checkout current revision'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.4'
+          tools: 'composer'
+          extensions: 'mbstring, intl, pdo_sqlite'
+
+      - name: 'Discover Composer cache directory'
+        id: 'cachedir'
+        run: 'echo "::set-output name=path::$(composer global config cache-dir)"'
+
+      - name: 'Share Composer cache across runs'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.cachedir.outputs.path }}'
+          key: "composer-lowest-${{ hashFiles('**/composer.json') }}"
+          restore-keys: |
+            composer-lowest-
+            composer-
+
+      - name: 'Update dependencies with Composer'
+        run: 'composer update --prefer-lowest --prefer-dist --no-interaction'
+
+      - name: 'Dump Composer autoloader'
+        run: 'composer dump-autoload --classmap-authoritative --no-cache'
+
+      - name: 'Run PHPUnit'
+        run: 'vendor/bin/phpunit'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+---
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 3
+
+coverage:
+  precision: 1
+  round: down
+  range: "85...100"
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+  after_n_builds: 2

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -105,7 +105,7 @@ ConnectionManager::alias('test', 'default');
 
 Router::reload();
 Security::setSalt('BEDITA');
-FrozenTime::setTestNow('2022-01-01T00:00:00+01:00');
+FrozenTime::setTestNow(new FrozenTime('2022-01-01T00:00:00+01:00'));
 
 // clear all before running tests
 TableRegistry::getTableLocator()->clear();


### PR DESCRIPTION
Running unit tests against lowest-matching dependencies helps finding out whether required constraints are too loose.