### PR TITLE
Restore correct behavior of `AwsS3CloudFrontAdapter`, which was never invalidating anything

### DIFF
--- a/src/Filesystem/Adapter/S3Adapter.php
+++ b/src/Filesystem/Adapter/S3Adapter.php
@@ -47,14 +47,14 @@ class S3Adapter extends FilesystemAdapter
      *
      * @var \Aws\S3\S3Client|null
      */
-    protected $client;
+    protected ?S3Client $client;
 
     /**
      * AWS CloudFront client.
      *
      * @var \Aws\CloudFront\CloudFrontClient|null
      */
-    protected $cloudFrontClient;
+    protected ?CloudFrontClient $cloudFrontClient;
 
     /**
      * @inheritDoc

--- a/src/Mailer/Transport/SesTransport.php
+++ b/src/Mailer/Transport/SesTransport.php
@@ -49,7 +49,7 @@ class SesTransport extends AbstractTransport
      *
      * @var \Aws\Ses\SesClient|null
      */
-    protected $client;
+    protected ?SesClient $client;
 
     /**
      * @inheritDoc
@@ -78,19 +78,19 @@ class SesTransport extends AbstractTransport
     /**
      * @inheritDoc
      */
-    public function send(Message $email): array
+    public function send(Message $message): array
     {
         $headerList = ['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc', 'subject'];
-        $headers = $email->getHeadersString($headerList, static::EOL);
+        $headers = $message->getHeadersString($headerList, static::EOL);
 
-        $message = $email->getBodyString(static::EOL);
+        $body = $message->getBodyString(static::EOL);
 
         $this->getClient()->sendRawEmail([
             'RawMessage' => [
-                'Data' => $headers . static::EOL . static::EOL . $message,
+                'Data' => $headers . static::EOL . static::EOL . $body,
             ],
         ]);
 
-        return compact('headers', 'message');
+        return ['headers' => $headers, 'message' => $body];
     }
 }

--- a/src/Mailer/Transport/SnsTransport.php
+++ b/src/Mailer/Transport/SnsTransport.php
@@ -43,7 +43,7 @@ class SnsTransport extends AbstractTransport
      *
      * @var \Aws\Sns\SnsClient|null
      */
-    protected $client;
+    protected ?SnsClient $client;
 
     /**
      * @inheritDoc
@@ -70,21 +70,16 @@ class SnsTransport extends AbstractTransport
     }
 
     /**
-     * Send mail
-     *
-     * @param \Cake\Mailer\Message $email Email message.
-     * @return array
+     * @inheritDoc
      */
-    public function send(Message $email): array
+    public function send(Message $message): array
     {
-        $from = $email->getFrom();
-        $to = $email->getTo();
+        $from = $message->getFrom();
+        $to = $message->getTo();
 
         $phoneNumber = reset($to);
         $senderId = trim(reset($from));
-        /** @var string $message */
-        $message = $email->getBodyText();
-        $message = trim($message);
+        $body = trim($message->getBodyText());
         $smsType = $this->getConfig('smsType');
 
         $attributes = [];
@@ -102,11 +97,11 @@ class SnsTransport extends AbstractTransport
         }
 
         $this->getClient()->publish([
-            'Message' => $message,
+            'Message' => $body,
             'PhoneNumber' => $phoneNumber,
             'MessageAttributes' => $attributes,
         ]);
 
-        return compact('message') + ['headers' => ''];
+        return ['headers' => '', 'message' => $body];
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,7 +21,7 @@ use BEdita\AWS\Mailer\Transport\SnsTransport;
 use BEdita\Core\Filesystem\FilesystemRegistry;
 use Cake\Core\BasePlugin;
 use Cake\Core\PluginApplicationInterface;
-use Cake\Mailer\Email;
+use Cake\Mailer\Mailer;
 
 /**
  * Plugin class.
@@ -36,7 +36,7 @@ class Plugin extends BasePlugin
         parent::bootstrap($app);
 
         // Register SES (email) and SNS (SMS) transports.
-        Email::setDsnClassMap([
+        Mailer::setDsnClassMap([
             'ses' => SesTransport::class,
             'sns' => SnsTransport::class,
         ]);

--- a/tests/TestCase/Authenticator/AlbAuthenticatorTest.php
+++ b/tests/TestCase/Authenticator/AlbAuthenticatorTest.php
@@ -35,6 +35,7 @@ use Lcobucci\JWT\Encoding\ChainedFormatter;
 use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Ecdsa\MultibyteStringConverter;
 use Lcobucci\JWT\Signer\Ecdsa\Sha256;
+use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\None;
 use Lcobucci\JWT\Token\Builder;
@@ -54,28 +55,28 @@ class AlbAuthenticatorTest extends TestCase
      *
      * @var string
      */
-    protected $keyId;
+    protected string $keyId;
 
     /**
      * Private key material.
      *
      * @var \Lcobucci\JWT\Signer\Key
      */
-    protected $privateKey;
+    protected Key $privateKey;
 
     /**
      * Requests history.
      *
      * @var array<int, array{request: \GuzzleHttp\Psr7\Request, response: \GuzzleHttp\Psr7\Response|null, error: \GuzzleHttp\Exception\GuzzleException|null, options: array}>
      */
-    protected $history = [];
+    protected array $history = [];
 
     /**
      * Guzzle HTTP handler.
      *
      * @var HandlerStack
      */
-    protected $handler;
+    protected HandlerStack $handler;
 
     /**
      * @inheritDoc

--- a/tests/TestCase/Mailer/Transport/SnsTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SnsTransportTest.php
@@ -84,7 +84,7 @@ class SnsTransportTest extends TestCase
     {
         return [
             'simple' => [
-                ['message' => 'Hello, world!', 'headers' => ''],
+                ['headers' => '', 'message' => 'Hello, world!'],
                 [
                     'Message' => 'Hello, world!',
                     'PhoneNumber' => '+1-202-555-0118',
@@ -98,7 +98,7 @@ class SnsTransportTest extends TestCase
                     ->setBodyText('Hello, world!'),
             ],
             'with sender' => [
-                ['message' => 'Hello, world!', 'headers' => ''],
+                ['headers' => '', 'message' => 'Hello, world!'],
                 [
                     'Message' => 'Hello, world!',
                     'PhoneNumber' => '+1-202-555-0118',
@@ -114,7 +114,7 @@ class SnsTransportTest extends TestCase
                     ->setBodyText('Hello, world!'),
             ],
             'with SMS type' => [
-                ['message' => 'Hello, world!', 'headers' => ''],
+                ['headers' => '', 'message' => 'Hello, world!'],
                 [
                     'Message' => 'Hello, world!',
                     'PhoneNumber' => '+1-202-555-0118',
@@ -130,7 +130,7 @@ class SnsTransportTest extends TestCase
                     ->setBodyText('Hello, world!'),
             ],
             'with sender and SMS type' => [
-                ['message' => 'Hello, world!', 'headers' => ''],
+                ['headers' => '', 'message' => 'Hello, world!'],
                 [
                     'Message' => 'Hello, world!',
                     'PhoneNumber' => '+1-202-555-0118',

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -34,7 +34,7 @@ class PluginTest extends TestCase
      *
      * @var \BEdita\AWS\Plugin
      */
-    protected $plugin;
+    protected Plugin $plugin;
 
     /**
      * @inheritDoc
@@ -55,9 +55,9 @@ class PluginTest extends TestCase
     public function testBootstrap(): void
     {
         $app = new class (CONFIG) extends BaseApplication {
-            public function middleware(MiddlewareQueue $middleware): MiddlewareQueue
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
             {
-                return $middleware;
+                return $middlewareQueue;
             }
         };
 


### PR DESCRIPTION
Resolves #7, among other issues introduced with #6 that caused `AwsS3CloudFrontAdapter` to never invalidate anything from the CloudFront distribution.