### PR TITLE
Fix JWT parsing error

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
     with:
-      php_versions: '["8.1"]'
+      php_versions: '["8.2"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
     with:
-      php_versions: '["8.1"]'
+      php_versions: '["8.2"]'
 
   unit:
     name: 'Run unit tests'
@@ -35,6 +35,7 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
 
     env:
       PHP_VERSION: '${{ matrix.php }}'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,7 +50,7 @@ jobs:
           php-version: '${{ matrix.php }}'
           tools: 'composer'
           extensions: 'mbstring, intl'
-          coverage: 'none' # Using `phpdbg`
+          coverage: 'xdebug'
 
       - name: 'Discover Composer cache directory'
         id: 'cachedir'
@@ -72,7 +72,7 @@ jobs:
         run: 'composer dump-autoload --classmap-authoritative --no-cache'
 
       - name: 'Run PHPUnit'
-        run: 'phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml'
+        run: 'vendor/bin/phpunit --coverage-clover=clover.xml'
 
       - name: 'Export coverage results'
         uses: 'codecov/codecov-action@v1'


### PR DESCRIPTION
This PR fixes an issue when parsing JWT issued by AWS Load Balancing, which do not strictly conform to spec and might include trailing `=` in each of the JWT dot-separated segments.

This PR uses a custom decoder that trims trailing `=` before supplying them to Sodium base64 decoder.

Additionally, since GitHub Actions runner on Ubuntu 22.04 do not seem to support ECDSA keys in PHP built by `shivammatur/setup-php`, tests have been refactored to invoke system `openssl` command instead.