### PR TITLE
S3Adapter public getClient

### DIFF
--- a/src/Filesystem/Adapter/S3Adapter.php
+++ b/src/Filesystem/Adapter/S3Adapter.php
@@ -96,7 +96,7 @@ class S3Adapter extends FilesystemAdapter
      *
      * @return \Aws\S3\S3Client
      */
-    protected function getClient(): S3Client
+    public function getClient(): S3Client
     {
         if (!empty($this->client)) {
             return $this->client;


### PR DESCRIPTION
This makes the `S3Adapter::getClient()` a `public` method. 