### PR TITLE
refactor: remove phpunit CoversMethod

### DIFF
--- a/tests/TestCase/Filesystem/Adapter/AwsS3CloudFrontAdapterTest.php
+++ b/tests/TestCase/Filesystem/Adapter/AwsS3CloudFrontAdapterTest.php
@@ -25,23 +25,12 @@ use DomainException;
 use InvalidArgumentException;
 use League\Flysystem\Config;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test {@see \BEdita\AWS\Filesystem\Adapter\AwsS3CloudFrontAdapter}.
  */
 #[CoversClass(AwsS3CloudFrontAdapter::class)]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, '__construct')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'applyCloudFrontPathPrefix')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'copy')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'createCloudFrontInvalidation')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'delete')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'deleteDirectory')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'getCloudFrontClient')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'getDistributionId')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'hasCloudFrontConfig')]
-#[CoversMethod(AwsS3CloudFrontAdapter::class, 'write')]
 
 class AwsS3CloudFrontAdapterTest extends TestCase
 {

--- a/tests/TestCase/Filesystem/Adapter/S3AdapterTest.php
+++ b/tests/TestCase/Filesystem/Adapter/S3AdapterTest.php
@@ -22,7 +22,6 @@ use BEdita\AWS\Filesystem\Adapter\S3Adapter;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -30,12 +29,6 @@ use PHPUnit\Framework\TestCase;
  * Test {@see \BEdita\AWS\Filesystem\Adapter\S3Adapter}
  */
 #[CoversClass(S3Adapter::class)]
-#[CoversMethod(S3Adapter::class, 'buildAdapter')]
-#[CoversMethod(S3Adapter::class, 'getClient')]
-#[CoversMethod(S3Adapter::class, 'getCloudFrontClient')]
-#[CoversMethod(S3Adapter::class, 'getPublicUrl')]
-#[CoversMethod(S3Adapter::class, 'initialize')]
-#[CoversMethod(S3Adapter::class, 'reformatConfig')]
 class S3AdapterTest extends TestCase
 {
     /**

--- a/tests/TestCase/Mailer/Transport/SesTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SesTransportTest.php
@@ -23,7 +23,6 @@ use Cake\I18n\DateTime;
 use Cake\Mailer\Message;
 use Cake\Utility\Text;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -31,9 +30,6 @@ use PHPUnit\Framework\TestCase;
  * Test {@see \BEdita\AWS\Mailer\Transport\SesTransport}.
  */
 #[CoversClass(SesTransport::class)]
-#[CoversMethod(SesTransport::class, '__construct')]
-#[CoversMethod(SesTransport::class, 'getClient')]
-#[CoversMethod(SesTransport::class, 'send')]
 class SesTransportTest extends TestCase
 {
     /**

--- a/tests/TestCase/Mailer/Transport/SnsTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SnsTransportTest.php
@@ -21,7 +21,6 @@ use Aws\Sns\SnsClient;
 use BEdita\AWS\Mailer\Transport\SnsTransport;
 use Cake\Mailer\Message;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -29,9 +28,6 @@ use PHPUnit\Framework\TestCase;
  * Test {@see \BEdita\AWS\Mailer\Transport\SnsTransport}.
  */
 #[CoversClass(SnsTransport::class)]
-#[CoversMethod(SnsTransport::class, '__construct')]
-#[CoversMethod(SnsTransport::class, 'getClient')]
-#[CoversMethod(SnsTransport::class, 'send')]
 class SnsTransportTest extends TestCase
 {
     /**


### PR DESCRIPTION
This removes phpunit `CoversMethod` from tests files.
It is not "repeatable", so it originated phpstan errors.
`CoversClass` is enough.